### PR TITLE
added support for the `void` type

### DIFF
--- a/src/main/kotlin/org/ton/intellij/tolk/type/ty/Ty.kt
+++ b/src/main/kotlin/org/ton/intellij/tolk/type/ty/Ty.kt
@@ -147,6 +147,12 @@ data object TolkTyBuilder : TolkTyAtomic() {
     override fun toString(): String = "builder"
 }
 
+data object TolkTyVoid : TolkTyAtomic() {
+    override val name: String = "void"
+
+    override fun toString(): String = "void"
+}
+
 data object TolkTyCont : TolkTyAtomic() {
     override val name: String = "cont"
 
@@ -173,6 +179,8 @@ val TolkTypeReference.rawType: TolkTy
                 TolkElementTypes.TUPLE_KEYWORD -> TolkTyAtomicTuple
                 else -> TolkTyUnknown
             }
+
+            is TolkVoidType -> TolkTyVoid
 
             is TolkTensorType -> TolkTy(
                 typeReferenceList.map {


### PR DESCRIPTION
before:
<img width="610" alt="Screenshot 2024-11-13 at 00 24 09" src="https://github.com/user-attachments/assets/0ada19f5-3c2f-4390-8605-97cdc2014f98">

after:
<img width="599" alt="Screenshot 2024-11-12 at 21 17 09" src="https://github.com/user-attachments/assets/8035da3f-3f8b-4f39-b1be-eef4fd170f5e">
