### PR TITLE
fix(tolk/inlay-hints): show `foo:` instead of `foo = `

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
@@ -25,7 +25,7 @@ class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
                     hasBackground = true,
                 ) {
                     printPsi(parameter, parameterName)
-                    text(" = ")
+                    text(":")
                 }
             }
         }


### PR DESCRIPTION
Fixes #234