### PR TITLE
fix(tolk/inlay-hints): don't show parameter hints for single letter parameters

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
@@ -18,6 +18,10 @@ class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
             element
         ) { parameter, argument ->
             val parameterName = parameter.name ?: return@iterateOverParameters
+
+            // There is no need to show a hint for single letter parameters as it does not add any information to the reader
+            if (parameterName.length == 1) return@iterateOverParameters
+
             val expression = argument?.expression?.unwrapParentheses() ?: return@iterateOverParameters
             if (expression !is TolkReferenceElement || expression.referenceName != parameterName) {
                 sink.addPresentation(


### PR DESCRIPTION
Fixes #251