### PR TITLE
fix(tolk/inlay-hints): don't show parameter hints for `ton()`

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
 import com.intellij.psi.PsiElement
 import org.ton.intellij.tolk.psi.TolkCallExpression
 import org.ton.intellij.tolk.psi.TolkReferenceElement
+import org.ton.intellij.tolk.psi.impl.functionSymbol
 import org.ton.intellij.tolk.psi.unwrapParentheses
 import org.ton.intellij.util.printPsi
 
@@ -14,6 +15,13 @@ class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
         sink: InlayTreeSink
     ) {
         if (element !is TolkCallExpression) return
+
+        val function = element.functionSymbol
+        if (function?.name == "ton") {
+            // Obvious and `floatString:` is too long for a parameter hint here
+            return
+        }
+
         iterateOverParameters(
             element
         ) { parameter, argument ->

--- a/modules/tolk/src/org/ton/intellij/tolk/psi/impl/TolkCallExpressionMixin.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/psi/impl/TolkCallExpressionMixin.kt
@@ -3,7 +3,9 @@ package org.ton.intellij.tolk.psi.impl
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import org.ton.intellij.tolk.psi.TolkCallExpression
+import org.ton.intellij.tolk.psi.TolkDotExpression
 import org.ton.intellij.tolk.psi.TolkFunction
+import org.ton.intellij.tolk.psi.TolkReferenceExpression
 import org.ton.intellij.tolk.type.TolkTy
 import org.ton.intellij.tolk.type.inference
 


### PR DESCRIPTION
Fixes #237