### PR TITLE
feat(tolk/inlay-hints): don't show parameter hints for same name field access and function/method call

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/codeInsight/hint/TolkParameterHintsProvider.kt
@@ -4,6 +4,8 @@ import com.intellij.codeInsight.hints.declarative.InlayTreeSink
 import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
 import com.intellij.psi.PsiElement
 import org.ton.intellij.tolk.psi.TolkCallExpression
+import org.ton.intellij.tolk.psi.TolkDotExpression
+import org.ton.intellij.tolk.psi.TolkExpression
 import org.ton.intellij.tolk.psi.TolkReferenceElement
 import org.ton.intellij.tolk.psi.impl.functionSymbol
 import org.ton.intellij.tolk.psi.unwrapParentheses
@@ -12,7 +14,7 @@ import org.ton.intellij.util.printPsi
 class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
     override fun collectFromElement(
         element: PsiElement,
-        sink: InlayTreeSink
+        sink: InlayTreeSink,
     ) {
         if (element !is TolkCallExpression) return
 
@@ -26,12 +28,9 @@ class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
             element
         ) { parameter, argument ->
             val parameterName = parameter.name ?: return@iterateOverParameters
-
-            // There is no need to show a hint for single letter parameters as it does not add any information to the reader
-            if (parameterName.length == 1) return@iterateOverParameters
-
             val expression = argument?.expression?.unwrapParentheses() ?: return@iterateOverParameters
-            if (expression !is TolkReferenceElement || expression.referenceName != parameterName) {
+
+            if (needParameterHint(expression, parameterName)) {
                 sink.addPresentation(
                     position = InlineInlayPosition(argument.textRange.startOffset, false),
                     hasBackground = true,
@@ -41,5 +40,32 @@ class TolkParameterHintsProvider : AbstractTolkInlayHintProvider() {
                 }
             }
         }
+    }
+
+    private fun needParameterHint(
+        expression: TolkExpression,
+        parameterName: String,
+    ): Boolean {
+        if (parameterName.length == 1) {
+            // no need to show a hint for single letter parameters as it does not add any information to the reader
+            return false
+        }
+
+        if (expression is TolkReferenceElement) {
+            // no need to show a hint for `takeFoo(foo)`
+            return expression.referenceName != parameterName
+        }
+
+        if (expression is TolkDotExpression) {
+            // no need to show a hint for `takeFoo(obj.foo)`
+            return expression.fieldLookup?.referenceName != parameterName
+        }
+
+        if (expression is TolkCallExpression) {
+            // no need to show a hint for `takeFoo(foo())`
+            return expression.functionSymbol?.name != parameterName
+        }
+
+        return true
     }
 }


### PR DESCRIPTION
Fixes #254