### PR TITLE
fix(tlb/lexer): allow identifiers starting with a number

### DIFF
--- a/modules/tlb/src/org/ton/intellij/tlb/lexer/TlbLexer.flex
+++ b/modules/tlb/src/org/ton/intellij/tlb/lexer/TlbLexer.flex
@@ -82,7 +82,7 @@ LINE_DOCUMENTATION = "/""/""/"[^\n]*
 LINE_COMMENT = "/""/"[^\n]*
 
 NUMBER=[0-9]+
-IDENTIFIER=[a-zA-Z_][0-9a-zA-Z0-9_]*
+IDENTIFIER=[0-9a-zA-Z_]*
 //PREDIFINED_TYPE=u?int[0-9]+|Cell
 
 %xstate BLOCK_COMMENT_STATE, DOC_COMMENT_STATE


### PR DESCRIPTION
Fixes #94

tlbc:

<img width="1432" height="376" alt="image" src="https://github.com/user-attachments/assets/882a57cc-3381-4d2e-a265-68b7f8b7d2dd" />
