### PR TITLE
feat(tolk/completion): don't add already processed types in match arm completion

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCommonCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCommonCompletionProvider.kt
@@ -142,7 +142,8 @@ object TolkCommonCompletionProvider : TolkCompletionProvider() {
                 is TolkConstVar,
                 is TolkGlobalVar,
                 is TolkTypeDef,
-                is TolkStruct -> {
+                is TolkStruct,
+                    -> {
                     fun canAddAsUnionMatchVariant(): Boolean {
                         if (!inMatchPattern) return false
                         if (declaredMatchArms.contains(name)) return false
@@ -150,8 +151,14 @@ object TolkCommonCompletionProvider : TolkCompletionProvider() {
                         val type = element.type ?: return false
                         return expectType.variants.any { it.canRhsBeAssigned(type) }
                     }
-                    val canAddByExpectType = expectType.canAddElement(element.type)
+
                     val canAddAsUnionMatchVariant = canAddAsUnionMatchVariant()
+                    if (inMatchPattern && !canAddAsUnionMatchVariant) {
+                        // already processed
+                        return true
+                    }
+
+                    val canAddByExpectType = expectType.canAddElement(element.type)
                     if (!canAddByExpectType && !canAddAsUnionMatchVariant) return true
                     if (!checkLimit()) return false
                     result.addElement(element.toLookupElement(currentFile, ctx))

--- a/modules/tolk/test/completion/TolkCompletionTest.kt
+++ b/modules/tolk/test/completion/TolkCompletionTest.kt
@@ -403,6 +403,65 @@ class TolkCompletionTest : TolkCompletionTestBase() {
         }
     """.trimIndent())
 
+    fun `test match arm completion, no completion items`() = checkNoCompletion("""
+        struct (0x7e8764ef) IncreaseCounter {
+            queryId: uint64
+            increaseBy: uint32
+        }
+        
+        struct (0x3a752f06) ResetCounter {
+            queryId: uint64
+        }
+
+        type AllowedMessage = IncreaseCounter | ResetCounter
+        
+        fun foo(msg: AllowedMessage) {
+            match (msg) {
+                IncreaseCounter => {}
+                ResetCounter => {}
+                /*caret*/
+            }
+        }
+    """)
+
+    fun `test match arm completion, single item`() = doSingleCompletion("""
+        struct (0x7e8764ef) IncreaseCounter {
+            queryId: uint64
+            increaseBy: uint32
+        }
+        
+        struct (0x3a752f06) ResetCounter {
+            queryId: uint64
+        }
+
+        type AllowedMessage = IncreaseCounter | ResetCounter
+        
+        fun foo(msg: AllowedMessage) {
+            match (msg) {
+                IncreaseCounter => {}
+                /*caret*/
+            }
+        }
+    """, """
+        struct (0x7e8764ef) IncreaseCounter {
+            queryId: uint64
+            increaseBy: uint32
+        }
+        
+        struct (0x3a752f06) ResetCounter {
+            queryId: uint64
+        }
+
+        type AllowedMessage = IncreaseCounter | ResetCounter
+        
+        fun foo(msg: AllowedMessage) {
+            match (msg) {
+                IncreaseCounter => {}
+                ResetCounter/*caret*/
+            }
+        }
+    """)
+
 //    fun `test caret navigation in self method`() = doSingleCompletion("""
 //        struct Foo;
 //        fun Foo.foo(self) {}


### PR DESCRIPTION
Fixes #274