### PR TITLE
feat(fift/documentation): add hover documentation for instructions

### DIFF
--- a/modules/fift/resources/META-INF/fift.xml
+++ b/modules/fift/resources/META-INF/fift.xml
@@ -22,6 +22,11 @@
         <colorSettingsPage implementation="org.ton.intellij.fift.ide.FiftColorSettingsPage"/>
         <lang.foldingBuilder language="Fift" implementationClass="org.ton.intellij.fift.ide.FiftFoldingBuilder"/>
 
+        <!-- region Documentation -->
+        <lang.documentationProvider language="Fift"
+                                    implementationClass="org.ton.intellij.fift.ide.documentation.FiftDocumentationProvider"/>
+        <!-- endregion Documentation -->
+
         <codeInsight.declarativeInlayProvider bundle="messages.FiftBundle"
                                               group="VALUES_GROUP"
                                               implementationClass="org.ton.intellij.fift.ide.hints.FiftAssemblyInfoHintsProvider"

--- a/modules/fift/src/org/ton/intellij/fift/ide/FiftDumbAnnotator.kt
+++ b/modules/fift/src/org/ton/intellij/fift/ide/FiftDumbAnnotator.kt
@@ -10,6 +10,7 @@ import org.ton.intellij.fift.psi.FiftDeclaration
 import org.ton.intellij.fift.psi.FiftDefinitionName
 import org.ton.intellij.fift.psi.FiftTvmInstruction
 import org.ton.intellij.fift.psi.FiftTypes
+import org.ton.intellij.fift.psi.isNotInstruction
 
 class FiftDumbAnnotator : Annotator, DumbAware {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
@@ -31,8 +32,7 @@ class FiftDumbAnnotator : Annotator, DumbAware {
 fun identifierColor(element: PsiElement): FiftColor? {
     return when (element) {
         is FiftTvmInstruction -> {
-            val firstChar = element.text[0]
-            if (firstChar !in 'A'..'Z' && firstChar !in '0'..'9' && firstChar != '-') {
+            if (element.isNotInstruction()) {
                 // foo CALLDICT
                 // ^^^
                 return FiftColor.ASSEMBLY_CALL

--- a/modules/fift/src/org/ton/intellij/fift/ide/documentation/DocumentationUtils.kt
+++ b/modules/fift/src/org/ton/intellij/fift/ide/documentation/DocumentationUtils.kt
@@ -1,0 +1,44 @@
+package org.ton.intellij.fift.ide.documentation
+
+import com.intellij.lang.documentation.DocumentationSettings
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
+import io.ktor.util.*
+import org.ton.intellij.fift.ide.FiftColor
+
+object DocumentationUtils {
+    private fun loadKey(key: TextAttributesKey): TextAttributes =
+        EditorColorsManager.getInstance().globalScheme.getAttributes(key)!!
+
+    val asAsmInstruction = loadKey(FiftColor.ASSEMBLY_INSTRUCTION.textAttributesKey)
+    val asComment = loadKey(FiftColor.COMMENT.textAttributesKey)
+
+    @Suppress("UnstableApiUsage")
+    fun StringBuilder.colorize(text: String, attrs: TextAttributes, noHtml: Boolean = false) {
+        if (noHtml) {
+            append(text)
+            return
+        }
+
+        HtmlSyntaxInfoUtil.appendStyledSpan(
+            this, attrs, text.escapeHTML(),
+            DocumentationSettings.getHighlightingSaturation(false)
+        )
+    }
+
+    fun StringBuilder.line(text: String?) {
+        if (text == null) {
+            return
+        }
+        append(text)
+        append("\n")
+    }
+
+    fun colorize(text: String, attrs: TextAttributes, noHtml: Boolean = false): String {
+        val sb = StringBuilder()
+        sb.colorize(text, attrs, noHtml)
+        return sb.toString()
+    }
+}

--- a/modules/fift/src/org/ton/intellij/fift/ide/documentation/FiftDocumentationProvider.kt
+++ b/modules/fift/src/org/ton/intellij/fift/ide/documentation/FiftDocumentationProvider.kt
@@ -1,0 +1,101 @@
+package org.ton.intellij.fift.ide.documentation
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+import org.ton.intellij.fift.ide.documentation.DocumentationUtils.asAsmInstruction
+import org.ton.intellij.fift.ide.documentation.DocumentationUtils.asComment
+import org.ton.intellij.fift.ide.documentation.DocumentationUtils.colorize
+import org.ton.intellij.fift.psi.FiftAsmExpression
+import org.ton.intellij.fift.psi.FiftTvmInstruction
+import org.ton.intellij.fift.psi.isNotInstruction
+import org.ton.intellij.util.asm.findInstruction
+import org.ton.intellij.util.asm.getStackPresentation
+
+class FiftDocumentationProvider : AbstractDocumentationProvider() {
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?) = when (element) {
+        is FiftTvmInstruction -> element.generateDoc()
+        else                  -> null
+    }
+
+    override fun getCustomDocumentationElement(editor: Editor, file: PsiFile, contextElement: PsiElement?, targetOffset: Int): PsiElement? {
+        val parent = contextElement?.parent
+        if (parent is FiftTvmInstruction) {
+            return parent
+        }
+        return super.getCustomDocumentationElement(editor, file, contextElement, targetOffset)
+    }
+}
+
+private class FiftDocMarkdownFlavourDescriptor(
+    private val gfm: MarkdownFlavourDescriptor = GFMFlavourDescriptor(useSafeLinks = false, absolutizeAnchorLinks = true),
+) : MarkdownFlavourDescriptor by gfm {}
+
+fun documentationAsHtml(documentationText: String): String {
+    val flavour = FiftDocMarkdownFlavourDescriptor()
+    val root = MarkdownParser(flavour).buildMarkdownTreeFromString(documentationText)
+    return HtmlGenerator(documentationText, root, flavour).generateHtml()
+}
+
+fun FiftTvmInstruction.generateDoc(): String? {
+    if (isNotInstruction()) return null
+
+    val expr = parent as? FiftAsmExpression ?: return "unknown instruction"
+    val instr = expr.tvmInstruction
+    val arguments = expr.asmArgumentList?.asmPrimitiveList ?: emptyList()
+
+    val info = findInstruction(instr.text, arguments) ?: return "unknown instruction"
+
+    val stackInfo = "<li>Stack (top is on the right): <code>${getStackPresentation(info.doc.stack)}</code></li>"
+
+    val gas = info.doc.gas.ifEmpty { "unknown" }
+
+    val actualInstructionDescription = mutableListOf(
+        wrapDefinition(colorize(info.mnemonic, asAsmInstruction)),
+        DocumentationMarkup.CONTENT_START,
+        "<ul>",
+        stackInfo,
+        "<li>Gas: <code>$gas</code></li>",
+        "</ul>",
+        documentationAsHtml(info.doc.description),
+        DocumentationMarkup.CONTENT_END,
+    )
+
+    val alias = info.aliasInfo
+    if (alias != null) {
+        val operandsStr = formatOperands(alias.operands) + " "
+        val aliasInfoDescription = " (alias of $operandsStr${alias.aliasOf})"
+
+        val aliasStackInfo = alias.docStack?.let {
+            "<li>Stack (top is on the right): <code>${getStackPresentation(it)}</code></li>"
+        } ?: ""
+
+        val withAliasDescription = listOf(
+            wrapDefinition(colorize(alias.mnemonic, asAsmInstruction) + colorize(aliasInfoDescription, asComment)),
+            DocumentationMarkup.CONTENT_START,
+            "<ul>",
+            aliasStackInfo,
+            "</ul>",
+            documentationAsHtml(alias.description ?: ""),
+            DocumentationMarkup.CONTENT_END,
+            "<hr>",
+            "Aliased instruction info:",
+            "<br>",
+        ) + actualInstructionDescription
+        return withAliasDescription.joinToString("\n")
+    }
+
+    return actualInstructionDescription.joinToString("\n")
+}
+
+fun formatOperands(operands: Map<String, Any?>): String {
+    return operands.values.joinToString(" ") { it.toString() }
+}
+
+fun wrapDefinition(content: String): String = DocumentationMarkup.DEFINITION_START + content + DocumentationMarkup.DEFINITION_END

--- a/modules/fift/src/org/ton/intellij/fift/ide/hints/FiftAssemblyInfoHintsProvider.kt
+++ b/modules/fift/src/org/ton/intellij/fift/ide/hints/FiftAssemblyInfoHintsProvider.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.ton.intellij.fift.psi.FiftAsmExpression
+import org.ton.intellij.fift.psi.isNotInstruction
 import org.ton.intellij.util.asm.findInstruction
 import org.ton.intellij.util.asm.instructionPresentation
 
@@ -16,9 +17,13 @@ class FiftAssemblyInfoHintsProvider : InlayHintsProvider {
             if (element !is FiftAsmExpression) return
 
             val instr = element.tvmInstruction
+            if (instr.isNotInstruction()) return
+            val name = instr.text
+            if (name == "INLINECALLDICT") return
+
             val arguments = element.asmArgumentList?.asmPrimitiveList ?: emptyList()
 
-            val info = findInstruction(instr.text, arguments)
+            val info = findInstruction(name, arguments)
 
             val presentation = instructionPresentation(info?.doc?.gas, info?.doc?.stack, "{gas}")
 

--- a/modules/fift/src/org/ton/intellij/fift/psi/elements.kt
+++ b/modules/fift/src/org/ton/intellij/fift/psi/elements.kt
@@ -57,3 +57,37 @@ abstract class FiftWordDefStatementMixin(node: ASTNode) : FiftNamedElementImpl(n
 abstract class FiftOrdinaryWordMixin(node: ASTNode) : FiftNamedElementImpl(node), FiftOrdinaryWord {
     override fun getReference() = FiftOrdinaryWordReference(this)
 }
+
+fun FiftTvmInstruction.isNotInstruction(): Boolean {
+    if (text.length < 3) return true
+
+    val firstChar = text[0]
+    if (firstChar in '0'..'9') {
+        // only instruction can start with a digit
+        return false
+    }
+
+    if (firstChar == '-') {
+        // -ROT, -ROLL
+        return false
+    }
+
+    if (firstChar == '~') {
+        // ~load_bool
+        return true
+    }
+
+    if (firstChar !in 'A'..'Z') {
+        // load_bool
+        return true
+    }
+
+    val secondChar = text[1]
+    if (secondChar !in 'A'..'Z') {
+        // Foo.bar()
+        return true
+    }
+
+    // INT
+    return false
+}

--- a/modules/util/src/org/ton/intellij/util/asm/Data.kt
+++ b/modules/util/src/org/ton/intellij/util/asm/Data.kt
@@ -100,16 +100,31 @@ fun adjustName(name: String, args: List<PsiElement>): String {
             }
         }
 
-        "PUSH"    -> {
+        "PUSH"           -> {
             if (args.size == 1 && args[0].text.startsWith("s")) return "PUSH"
             if (args.size == 2) return "PUSH2"
             if (args.size == 3) return "PUSH3"
             name
         }
 
-        "XCHG0"   -> "XCHG_0I"
-        "XCHG"    -> "XCHG_IJ"
-        else      -> name
+        "XCHG0"          -> "XCHG_0I"
+        "XCHG"           -> "XCHG_IJ"
+        "SKIPOPTREF"     -> "SKIPDICT"
+        "STOPTREF"       -> "STDICT"
+        "LDOPTREF"       -> "LDDICT"
+        "PLDOPTREF"      -> "PLDDICT"
+        "PUSHNULL"       -> "NULL"
+        "FALSE"          -> "PUSHINT_4"
+        "-ROT"           -> "ROTREV"
+        "-ROLL"          -> "BLKSWAP"
+        "2DROP"          -> "DROP2"
+        "2SWAP"          -> "SWAP2"
+        "2DUP"           -> "DUP2"
+        "2OVER"          -> "OVER2"
+        "LDVARUINT16"    -> "LDGRAMS"
+        "STVARUINT16"    -> "STGRAMS"
+        "INLINECALLDICT" -> "CALLDICT"
+        else             -> name
     }
 }
 


### PR DESCRIPTION
Fixes #319
<img width="449" height="328" alt="Screenshot 2025-07-30 at 21 20 38" src="https://github.com/user-attachments/assets/fec1f43a-4699-4d63-b026-4bc258f772cb" />

<img width="442" height="426" alt="Screenshot 2025-07-30 at 21 20 33" src="https://github.com/user-attachments/assets/d32539b2-4908-4f81-8fe0-8166002d09e1" />
