### PR TITLE
feat(func/documentation): add hover documentation for assembly instructions

### DIFF
--- a/modules/asm/resources/META-INF/asm.xml
+++ b/modules/asm/resources/META-INF/asm.xml
@@ -11,5 +11,10 @@
                                        implementationClass="org.ton.intellij.asm.AsmSyntaxHighlighterFactory"/>
         <completion.contributor language="TVM assembly"
                                 implementationClass="org.ton.intellij.asm.AsmCompletionContributor"/>
+
+        <!-- region Documentation -->
+        <lang.documentationProvider language="TVM assembly"
+                                    implementationClass="org.ton.intellij.asm.ide.documentation.AsmDocumentationProvider"/>
+        <!-- endregion Documentation -->
     </extensions>
 </idea-plugin>

--- a/modules/asm/src/org/ton/intellij/asm/AsmHighlighter.kt
+++ b/modules/asm/src/org/ton/intellij/asm/AsmHighlighter.kt
@@ -1,13 +1,10 @@
 package org.ton.intellij.asm
 
 import com.intellij.lexer.Lexer
-import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
-import com.intellij.openapi.editor.HighlighterColors
-import com.intellij.openapi.editor.XmlHighlighterColors
 import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.psi.tree.IElementType
+import org.ton.intellij.asm.ide.AsmColor
 import org.ton.intellij.asm.lexer.AsmLexer
 import org.ton.intellij.asm.psi.AsmElementTypes
 
@@ -18,22 +15,13 @@ object AsmHighlighter : SyntaxHighlighterBase() {
 
     override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> {
         return when (tokenType) {
-            com.intellij.psi.TokenType.BAD_CHARACTER -> BAD_CHARACTER
-            AsmElementTypes.INTEGER -> NUMBER
-            AsmElementTypes.STACK_REGISTER -> STACK_REGISTER
-            AsmElementTypes.CONTROL_REGISTER -> CONTROL_REGISTER
-            else -> INSTRUCTION
+            com.intellij.psi.TokenType.BAD_CHARACTER -> AsmColor.BAD_CHARACTER
+            AsmElementTypes.INTEGER                  -> AsmColor.NUMBER
+            AsmElementTypes.STACK_REGISTER           -> AsmColor.STACK_REGISTER
+            AsmElementTypes.CONTROL_REGISTER         -> AsmColor.CONTROL_REGISTER
+            else                                     -> AsmColor.INSTRUCTION
         }.let {
-            pack(it)
+            pack(it.textAttributesKey)
         }
     }
-
-    private val BAD_CHARACTER = createTextAttributesKey("ASM.BAD_CHARACTER", HighlighterColors.BAD_CHARACTER)
-    private val INSTRUCTION =
-        createTextAttributesKey("ASM.INSTRUCTION", XmlHighlighterColors.HTML_TAG)
-    private val NUMBER = createTextAttributesKey("ASM.NUMBER", DefaultLanguageHighlighterColors.NUMBER)
-    private val STACK_REGISTER =
-        createTextAttributesKey("ASM.STACK_REGISTER", DefaultLanguageHighlighterColors.CONSTANT)
-    private val CONTROL_REGISTER =
-        createTextAttributesKey("ASM.STACK_REGISTER", DefaultLanguageHighlighterColors.CONSTANT)
 }

--- a/modules/asm/src/org/ton/intellij/asm/ide/AsmColor.kt
+++ b/modules/asm/src/org/ton/intellij/asm/ide/AsmColor.kt
@@ -1,0 +1,25 @@
+package org.ton.intellij.asm.ide
+
+import com.intellij.openapi.editor.HighlighterColors
+import com.intellij.openapi.editor.XmlHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors as Defaults
+
+enum class AsmColor(
+    displayName: String,
+    default: TextAttributesKey,
+) {
+    BAD_CHARACTER("Bad character", HighlighterColors.BAD_CHARACTER),
+    COMMENT("Comment", Defaults.LINE_COMMENT),
+
+    NUMBER("Number", Defaults.NUMBER),
+    STACK_REGISTER("Stack register", Defaults.CONSTANT),
+    CONTROL_REGISTER("Control register", Defaults.CONSTANT),
+    INSTRUCTION("Assembly instruction", XmlHighlighterColors.HTML_TAG)
+    ;
+
+    val textAttributesKey =
+        TextAttributesKey.createTextAttributesKey("org.ton.intellij.fift.$name", default)
+    val attributesDescriptor = AttributesDescriptor(displayName, textAttributesKey)
+}

--- a/modules/asm/src/org/ton/intellij/asm/ide/documentation/AsmDocumentationProvider.kt
+++ b/modules/asm/src/org/ton/intellij/asm/ide/documentation/AsmDocumentationProvider.kt
@@ -1,0 +1,93 @@
+package org.ton.intellij.asm.ide.documentation
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+import org.ton.intellij.asm.ide.documentation.DocumentationUtils.asAsmInstruction
+import org.ton.intellij.asm.ide.documentation.DocumentationUtils.asComment
+import org.ton.intellij.asm.ide.documentation.DocumentationUtils.colorize
+import org.ton.intellij.asm.psi.AsmInstruction
+import org.ton.intellij.util.asm.findInstruction
+import org.ton.intellij.util.asm.getStackPresentation
+
+class AsmDocumentationProvider : AbstractDocumentationProvider() {
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?) = when (element) {
+        is AsmInstruction -> element.generateDoc()
+        else              -> null
+    }
+
+    override fun getCustomDocumentationElement(editor: Editor, file: PsiFile, contextElement: PsiElement?, targetOffset: Int): PsiElement? {
+        val parent = contextElement?.parent
+        if (parent is AsmInstruction) {
+            return parent
+        }
+        return super.getCustomDocumentationElement(editor, file, contextElement, targetOffset)
+    }
+}
+
+private class FiftDocMarkdownFlavourDescriptor(
+    private val gfm: MarkdownFlavourDescriptor = GFMFlavourDescriptor(useSafeLinks = false, absolutizeAnchorLinks = true),
+) : MarkdownFlavourDescriptor by gfm
+
+fun documentationAsHtml(documentationText: String): String {
+    val flavour = FiftDocMarkdownFlavourDescriptor()
+    val root = MarkdownParser(flavour).buildMarkdownTreeFromString(documentationText)
+    return HtmlGenerator(documentationText, root, flavour).generateHtml()
+}
+
+fun AsmInstruction.generateDoc(): String {
+    val info = findInstruction(text, listOf()) ?: return "unknown instruction"
+
+    val stackInfo = "<li>Stack (top is on the right): <code>${getStackPresentation(info.doc.stack)}</code></li>"
+
+    val gas = info.doc.gas.ifEmpty { "unknown" }
+
+    val actualInstructionDescription = mutableListOf(
+        wrapDefinition(colorize(info.mnemonic, asAsmInstruction)),
+        DocumentationMarkup.CONTENT_START,
+        "<ul>",
+        stackInfo,
+        "<li>Gas: <code>$gas</code></li>",
+        "</ul>",
+        documentationAsHtml(info.doc.description),
+        DocumentationMarkup.CONTENT_END,
+    )
+
+    val alias = info.aliasInfo
+    if (alias != null) {
+        val operandsStr = formatOperands(alias.operands) + " "
+        val aliasInfoDescription = " (alias of $operandsStr${alias.aliasOf})"
+
+        val aliasStackInfo = alias.docStack?.let {
+            "<li>Stack (top is on the right): <code>${getStackPresentation(it)}</code></li>"
+        } ?: ""
+
+        val withAliasDescription = listOf(
+            wrapDefinition(colorize(alias.mnemonic, asAsmInstruction) + colorize(aliasInfoDescription, asComment)),
+            DocumentationMarkup.CONTENT_START,
+            "<ul>",
+            aliasStackInfo,
+            "</ul>",
+            documentationAsHtml(alias.description ?: ""),
+            DocumentationMarkup.CONTENT_END,
+            "<hr>",
+            "Aliased instruction info:",
+            "<br>",
+        ) + actualInstructionDescription
+        return withAliasDescription.joinToString("\n")
+    }
+
+    return actualInstructionDescription.joinToString("\n")
+}
+
+fun formatOperands(operands: Map<String, Any?>): String {
+    return operands.values.joinToString(" ") { it.toString() }
+}
+
+fun wrapDefinition(content: String): String = DocumentationMarkup.DEFINITION_START + content + DocumentationMarkup.DEFINITION_END

--- a/modules/asm/src/org/ton/intellij/asm/ide/documentation/DocumentationUtils.kt
+++ b/modules/asm/src/org/ton/intellij/asm/ide/documentation/DocumentationUtils.kt
@@ -1,0 +1,44 @@
+package org.ton.intellij.asm.ide.documentation
+
+import com.intellij.lang.documentation.DocumentationSettings
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.editor.richcopy.HtmlSyntaxInfoUtil
+import io.ktor.util.*
+import org.ton.intellij.asm.ide.AsmColor
+
+object DocumentationUtils {
+    private fun loadKey(key: TextAttributesKey): TextAttributes =
+        EditorColorsManager.getInstance().globalScheme.getAttributes(key)!!
+
+    val asAsmInstruction = loadKey(AsmColor.INSTRUCTION.textAttributesKey)
+    val asComment = loadKey(AsmColor.COMMENT.textAttributesKey)
+
+    @Suppress("UnstableApiUsage")
+    fun StringBuilder.colorize(text: String, attrs: TextAttributes, noHtml: Boolean = false) {
+        if (noHtml) {
+            append(text)
+            return
+        }
+
+        HtmlSyntaxInfoUtil.appendStyledSpan(
+            this, attrs, text.escapeHTML(),
+            DocumentationSettings.getHighlightingSaturation(false)
+        )
+    }
+
+    fun StringBuilder.line(text: String?) {
+        if (text == null) {
+            return
+        }
+        append(text)
+        append("\n")
+    }
+
+    fun colorize(text: String, attrs: TextAttributes, noHtml: Boolean = false): String {
+        val sb = StringBuilder()
+        sb.colorize(text, attrs, noHtml)
+        return sb.toString()
+    }
+}

--- a/modules/asm/src/org/ton/intellij/asm/parser/AsmParser.bnf
+++ b/modules/asm/src/org/ton/intellij/asm/parser/AsmParser.bnf
@@ -41,4 +41,7 @@ Verb ::= INTEGER | SLICE_BINARY | SLICE_HEX
  | CODE_END
  | CODE_END_CELL
  | CODE_END_SLICE
- | WORD
+ | Instruction
+
+Instruction ::= WORD
+


### PR DESCRIPTION


Fixes #327
<img width="605" height="567" alt="Screenshot 2025-07-30 at 22 07 46" src="https://github.com/user-attachments/assets/eb81f774-2576-4c56-a3e3-35656d5d5b07" />
