### PR TITLE
feat(func/highlighting): better highlighting for method calls

### DIFF
--- a/modules/func/resources/META-INF/func.xml
+++ b/modules/func/resources/META-INF/func.xml
@@ -45,6 +45,8 @@
         <breadcrumbsInfoProvider implementation="org.ton.intellij.func.structure.FuncBreadcrumbsInfoProvider"/>
 
         <colorSettingsPage implementation="org.ton.intellij.func.ide.colors.FuncColorSettingsPage"/>
+        <additionalTextAttributes scheme="Default" file="colorSchemes/FuncDefault.xml"/>
+        <additionalTextAttributes scheme="Dark" file="colorSchemes/FuncDark.xml"/>
 
         <typedHandler implementation="org.ton.intellij.func.editor.FuncTypedHandler" id="FuncTypedHandler"/>
 

--- a/modules/func/resources/colorSchemes/FuncDark.xml
+++ b/modules/func/resources/colorSchemes/FuncDark.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<list>
+    <option name="org.ton.intellij.func.FUNCTION_CALL">
+        <value>
+            <option name="FOREGROUND" value="56A8F5"/>
+        </value>
+    </option>
+</list>

--- a/modules/func/resources/colorSchemes/FuncDefault.xml
+++ b/modules/func/resources/colorSchemes/FuncDefault.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0'?>
+<list>
+    <option name="org.ton.intellij.func.FUNCTION_CALL">
+        <value>
+            <option name="FOREGROUND" value="627a" />
+        </value>
+    </option>
+</list>


### PR DESCRIPTION
Fixes #351

Before:

<img width="588" height="381" alt="Screenshot 2025-07-31 at 16 21 49" src="https://github.com/user-attachments/assets/2b1ed766-26a6-4e00-86c9-9f2453075435" />

After:

<img width="660" height="384" alt="Screenshot 2025-07-31 at 16 23 14" src="https://github.com/user-attachments/assets/3b46b862-b2c6-4fba-9e91-829146ed519b" />
