### PR TITLE
feat(tlb/highlighting): use default field color for TL-B fields

### DIFF
--- a/modules/tlb/src/org/ton/intellij/tlb/ide/colors.kt
+++ b/modules/tlb/src/org/ton/intellij/tlb/ide/colors.kt
@@ -29,11 +29,12 @@ enum class TlbColor(
     CONSTRUCTOR_NAME("Constructor name", Defaults.STATIC_METHOD),
     HEX_TAG("HEX Tag", Defaults.STATIC_FIELD),
     BINARY_TAG("Binary Tag", Defaults.STATIC_FIELD),
-    FIELD_NAME("Field name", XmlHighlighterColors.HTML_ATTRIBUTE_NAME),
+    FIELD_NAME("Field name", Defaults.INSTANCE_FIELD),
     TYPE_PARAMETER("Type parameter", TextAttributesKey.find("TYPE_PARAMETER_NAME_ATTRIBUTES")),
     CONSTRUCTOR_TYPE_NAME("Constructor type name", Defaults.KEYWORD),
     IMPLICIT_FIELD_NAME("Implicit field name", XmlHighlighterColors.HTML_ATTRIBUTE_VALUE),
-    BUILTIN_TYPE("Builtin type", XmlHighlighterColors.HTML_ATTRIBUTE_VALUE)
+    BUILTIN_TYPE("Builtin type", XmlHighlighterColors.HTML_ATTRIBUTE_VALUE),
+    IDENTIFIER("Identifier",  XmlHighlighterColors.HTML_ATTRIBUTE_NAME),
     ;
 
     val textAttributesKey =

--- a/modules/tlb/src/org/ton/intellij/tlb/ide/highlighter.kt
+++ b/modules/tlb/src/org/ton/intellij/tlb/ide/highlighter.kt
@@ -26,7 +26,7 @@ object TlbSyntaxHighlighter : SyntaxHighlighterBase() {
         HEX_TAG -> TlbColor.HEX_TAG
         BINARY_TAG -> TlbColor.BINARY_TAG
         PREDIFINED_TYPE -> TlbColor.IMPLICIT_FIELD_NAME
-        IDENTIFIER -> TlbColor.FIELD_NAME
+        IDENTIFIER -> TlbColor.IDENTIFIER
         CIRCUMFLEX, COLUMN, EQ -> TlbColor.OPERATION_SIGN
         in TlbParserDefinition.BUILTIN_TYPES -> TlbColor.IMPLICIT_FIELD_NAME
         else -> null


### PR DESCRIPTION
Fixes #357

Before:
<img width="515" height="279" alt="Screenshot 2025-08-01 at 16 13 25" src="https://github.com/user-attachments/assets/c9a2561d-6134-43c0-b8fb-d7e3e4f6f8c6" />

After:
<img width="463" height="234" alt="Screenshot 2025-08-01 at 16 13 01" src="https://github.com/user-attachments/assets/8555ef28-a24a-4831-ae36-de495b084b1c" />

