### PR TITLE
feat(tolk/documentation): resolve element links like `[param]` in rendered doc

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/doc/MarkdownNode.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/MarkdownNode.kt
@@ -2,6 +2,7 @@
 
 package org.ton.intellij.tolk.doc
 
+import com.intellij.codeInsight.documentation.DocumentationManagerUtil
 import com.intellij.lang.Language
 import com.intellij.lang.documentation.DocumentationSettings
 import com.intellij.openapi.application.ApplicationManager
@@ -140,11 +141,25 @@ class MarkdownNode(
                     val linkLabelContent = linkLabelNode?.children
                         ?.dropWhile { it.type == MarkdownTokenTypes.LBRACKET }
                         ?.dropLastWhile { it.type == MarkdownTokenTypes.RBRACKET }
+
                     if (linkLabelContent != null) {
-                        // val label = linkLabelContent.joinToString(separator = "") { it.text }
-                        // val linkText = node.child(MarkdownElementTypes.LINK_TEXT)?.toHtml() ?: label
-                        // TODO: resolve `[foo]` to symbol.
-                        sb.append(node.text)
+                        val label = linkLabelContent.joinToString(separator = "") { it.text }
+                        val linkText = node.child(MarkdownElementTypes.LINK_TEXT)?.toHtml() ?: label
+
+                        val resolved = resolveDocumentationReference(linkText, owner.parent)
+                        if (resolved != null) {
+                            val hyperlink = buildString {
+                                DocumentationManagerUtil.createHyperlink(
+                                    this,
+                                    label,
+                                    linkText,
+                                    false,
+                                )
+                            }
+                            sb.append(hyperlink)
+                        } else {
+                            sb.append(node.text)
+                        }
                     } else {
                         sb.append(node.text)
                     }

--- a/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiDocCommentBase
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import com.intellij.psi.SyntaxTraverser
 import org.ton.intellij.tolk.doc.TolkDocumentationUtils.appendNotNull
 import org.ton.intellij.tolk.doc.TolkDocumentationUtils.asAnnotation
@@ -97,6 +98,10 @@ class TolkDocumentationProvider : AbstractDocumentationProvider() {
 
     override fun generateRenderedDoc(comment: PsiDocCommentBase): String? {
         return (comment as? TolkDocComment)?.renderHtml()
+    }
+
+    override fun getDocumentationElementForLink(psiManager: PsiManager?, link: String, context: PsiElement): PsiElement? {
+        return resolveDocumentationReference(link, context)
     }
 }
 

--- a/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationUtils.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationUtils.kt
@@ -1,7 +1,19 @@
 package org.ton.intellij.tolk.doc
 
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.util.Processor
 import org.ton.intellij.tolk.ide.colors.TolkColor
+import org.ton.intellij.tolk.psi.TolkFile
+import org.ton.intellij.tolk.psi.TolkFunction
+import org.ton.intellij.tolk.psi.TolkStruct
+import org.ton.intellij.tolk.psi.TolkTypeDef
+import org.ton.intellij.tolk.psi.TolkTypedElement
+import org.ton.intellij.tolk.psi.impl.hasReceiver
+import org.ton.intellij.tolk.psi.impl.receiverTy
+import org.ton.intellij.tolk.psi.impl.structFields
+import org.ton.intellij.tolk.stub.index.TolkNamedElementIndex
 import org.ton.intellij.util.doc.DocumentationUtils
 
 object TolkDocumentationUtils : DocumentationUtils() {
@@ -23,4 +35,127 @@ object TolkDocumentationUtils : DocumentationUtils() {
     val asStruct get() = loadKey(TolkColor.STRUCT.textAttributesKey)
     val asTypeAlias get() = loadKey(TolkColor.TYPE_ALIAS.textAttributesKey)
     val asPrimitive get() = loadKey(TolkColor.PRIMITIVE.textAttributesKey)
+}
+
+fun resolveDocumentationReference(name: String, owner: PsiElement): PsiElement? {
+    val containingFile = owner.containingFile as? TolkFile ?: return null
+
+    if (name.contains(".")) {
+        // `Foo.name`, field or method
+        val parts = name.split(".")
+        if (parts.size != 2) {
+            // unexpected
+            return null
+        }
+
+        val typeName = parts[0]
+        val methodOrFieldName = parts[1]
+
+        val typeReference = resolveDocumentationTypeReference(containingFile, typeName) ?: return null
+        if (typeReference is TolkStruct) {
+            val fields = typeReference.structFields
+            for (field in fields) {
+                if (field.name == methodOrFieldName) {
+                    return field
+                }
+            }
+        }
+
+        val searchReceiverType = (typeReference as? TolkTypedElement)?.type ?: return null
+
+        var foundElement: PsiElement? = null
+
+        TolkNamedElementIndex.processAllElements(owner.project, GlobalSearchScope.allScope(owner.project), Processor { element ->
+            if (element !is TolkFunction) return@Processor true
+            if (!element.hasReceiver) return@Processor true
+            if (element.name != methodOrFieldName) return@Processor true
+
+            val receiverType = element.receiverTy
+            if (receiverType.isEquivalentTo(searchReceiverType)) {
+                foundElement = element
+                return@Processor false
+            }
+
+            true
+        })
+
+        return foundElement
+    }
+
+    if (owner is TolkFunction) {
+        val params = owner.parameterList?.parameterList ?: emptyList()
+        for (param in params) {
+            if (param.name == name) {
+                return param
+            }
+        }
+        val typeParams = owner.typeParameterList?.typeParameterList ?: emptyList()
+        for (param in typeParams) {
+            if (param.name == name) {
+                return param
+            }
+        }
+    }
+
+    if (owner is TolkStruct) {
+        val typeParams = owner.typeParameterList?.typeParameterList ?: emptyList()
+        for (param in typeParams) {
+            if (param.name == name) {
+                return param
+            }
+        }
+
+        val fields = owner.structFields
+        for (field in fields) {
+            if (field.name == name) {
+                return field
+            }
+        }
+    }
+
+    if (owner is TolkTypeDef) {
+        val typeParams = owner.typeParameterList?.typeParameterList ?: emptyList()
+        for (param in typeParams) {
+            if (param.name == name) {
+                return param
+            }
+        }
+    }
+
+    for (func in containingFile.functions) {
+        if (func.name == name) {
+            return func
+        }
+    }
+    for (constant in containingFile.constVars) {
+        if (constant.name == name) {
+            return constant
+        }
+    }
+    for (global in containingFile.globalVars) {
+        if (global.name == name) {
+            return global
+        }
+    }
+
+    val typeReference = resolveDocumentationTypeReference(containingFile, name)
+    if (typeReference != null) {
+        return typeReference
+    }
+
+    return null
+}
+
+private fun resolveDocumentationTypeReference(containingFile: TolkFile, name: String): PsiElement? {
+    for (alias in containingFile.typeDefs) {
+        if (alias.name == name) {
+            return alias
+        }
+    }
+    for (struct in containingFile.structs) {
+        if (struct.name == name) {
+            return struct
+        }
+    }
+    return null
 }


### PR DESCRIPTION


Fixes #419

<img width="996" height="365" alt="Screenshot 2025-08-28 at 15 12 05" src="https://github.com/user-attachments/assets/dfb54f50-5ac9-4f3e-9124-586423d95936" />
<img width="552" height="405" alt="Screenshot 2025-08-28 at 15 12 19" src="https://github.com/user-attachments/assets/2c2d8b39-3f3e-4245-b3c8-8f9c333e39b2" />
