### PR TITLE
fix(tolk/type-inference): correctly infer `never` return type for function that always throws

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/inspection/TolkTypeMismatchInspection.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/inspection/TolkTypeMismatchInspection.kt
@@ -72,7 +72,7 @@ class TolkTypeMismatchInspection : TolkInspectionBase() {
 
             args.forEachIndexed { i, arg ->
                 val argType = arg.expression.type ?: return@forEachIndexed
-                val param = params[i]
+                val param = params.getOrNull(i) ?: return@forEachIndexed
                 val paramType = param.type ?: return@forEachIndexed
 
                 if (!paramType.canRhsBeAssigned(argType)) {

--- a/modules/tolk/test/codeInsight/TolkCodeInsightTest.kt
+++ b/modules/tolk/test/codeInsight/TolkCodeInsightTest.kt
@@ -91,4 +91,5 @@ class TolkCodeInsightTest : TolkCodeInsightBaseTest() {
     fun `test var-apply-tests`() = doTest()
 
     fun `test enums-tests`() = doTest()
+    fun `test never-return-functions`() = doTest()
 }

--- a/modules/tolk/testResources/org.ton.intellij.tolk/tests/inference-tests.tolk
+++ b/modules/tolk/testResources/org.ton.intellij.tolk/tests/inference-tests.tolk
@@ -111,7 +111,7 @@ fun alwaysThrowsNotAnnotated2() { alwaysThrows(); }
 fun test9() {
     __expect_type(alwaysThrows(), "never");
     __expect_type(alwaysThrows, "() -> never");
-    __expect_type(alwaysThrowsNotAnnotated(), "void");
+    __expect_type(alwaysThrowsNotAnnotated(), "never");
     __expect_type(alwaysThrowsNotAnnotated2(), "void");
 }
 

--- a/modules/tolk/testResources/org.ton.intellij.tolk/tests/never-return-functions.tolk
+++ b/modules/tolk/testResources/org.ton.intellij.tolk/tests/never-return-functions.tolk
@@ -1,0 +1,31 @@
+fun alwaysThrows() {
+    throw 10
+}
+
+fun alwaysThrowsWithConditions(a: bool) {
+    if (a) {
+        throw 10;
+    }
+    throw 1 ;
+}
+
+fun lastThrowAndConditionalReturn(a: bool) {
+    if (a) {
+        return 10;
+    }
+    throw 1 ;
+}
+
+fun conditionallyThrow(a: bool) {
+    if (a) {
+        throw 1
+    }
+    return 10
+}
+
+fun main() {
+    __expect_type(alwaysThrows(), "never");
+    __expect_type(alwaysThrowsWithConditions(true), "never");
+    __expect_type(lastThrowAndConditionalReturn(true), "int");
+    __expect_type(conditionallyThrow(true), "int");
+}


### PR DESCRIPTION


Fixes #421