### PR TITLE
fix(tolk/resolving): fallback to resolve by any methods only if the receiver has an unknown type

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/psi/reference/TolkFieldLookupReference.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/psi/reference/TolkFieldLookupReference.kt
@@ -186,18 +186,17 @@ fun collectMethodCandidates(
     }
 
     if (viable.isEmpty()) {
-        if (forCompletion) {
-            return emptyList()
+        if (calledReceiver is TolkTyUnknown) {
+            // We cannot always infer a type of generic functions like
+            // ```
+            // fun getWrapperValue2<T>(c: T) {
+            //    return c.value;
+            // }
+            // ```
+            // so fallback to an initial methods list to resolve somehow
+            return methods.map { it to EmptySubstitution }
         }
-
-        // We cannot always infer a type of generic functions like
-        // ```
-        // fun getWrapperValue2<T>(c: T) {
-        //    return c.value;
-        // }
-        // ```
-        // so fallback to initial methods list to resolve somehow
-        return methods.map { it to EmptySubstitution }
+        return emptyList()
     }
 
     // if nothing found, return nothing;


### PR DESCRIPTION


Fixes #498