### PR TITLE
feat(func/inspections): warn about function with `()` return type and without `impure` modifier

### DIFF
--- a/modules/func/resources/META-INF/func.xml
+++ b/modules/func/resources/META-INF/func.xml
@@ -155,6 +155,12 @@
                          groupKey="group.general.name"
                          enabledByDefault="true" level="WARNING"
                          implementationClass="org.ton.intellij.func.inspection.style.FuncOperatorPrecedenceInspection"/>
+        <localInspection language="FunC" groupPath="FunC"
+                         bundle="messages.FuncBundle"
+                         key="inspection.func.missing.impure.name"
+                         groupKey="group.general.name"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="org.ton.intellij.func.inspection.style.FuncMissingImpureInspection"/>
 
         <!-- Completion -->
         <completion.contributor language="FunC"

--- a/modules/func/resources/inspectionDescriptions/FuncMissingImpure.html
+++ b/modules/func/resources/inspectionDescriptions/FuncMissingImpure.html
@@ -1,0 +1,32 @@
+<html>
+<body>
+Reports functions returning unit type <code>()</code> that may need the <code>impure</code> specifier to prevent
+compiler optimization.
+
+<p>
+    In FunC, functions that return nothing (unit type <code>()</code>) typically have side effects and should be marked
+    with the <code>impure</code> specifier.
+    <strong>Without the <code>impure</code> specifier, the compiler may optimize away such functions completely</strong>,
+    leading to unexpected behavior and debugging difficulties.
+</p>
+
+<br>
+<b>Problematic (may be optimized away):</b>
+<pre><code>
+() send_message(cell msg) {
+    send_raw_message(msg, 0);
+}
+</code></pre>
+<b>Correct (protected from optimization):</b>
+<pre><code>
+() send_message(cell msg) impure {
+    send_raw_message(msg, 0);
+}
+</code></pre>
+<br>
+
+<p>
+    The inspection provides a quick fix to add the <code>impure</code> specifier automatically.
+</p>
+</body>
+</html>

--- a/modules/func/resources/messages/FuncBundle.properties
+++ b/modules/func/resources/messages/FuncBundle.properties
@@ -32,3 +32,8 @@ inspection.func.operator.precedence.name=Suspicious operator precedence
 inspection.func.operator.precedence.message=Suspicious operator precedence, consider adding parentheses for clarity
 inspection.func.operator.precedence.fix.family.name=Add parentheses for clarity
 inspection.func.operator.precedence.fix.text=Add parentheses to clarify precedence
+
+inspection.func.missing.impure.name=Missing 'impure' specifier
+inspection.func.missing.impure.message=Function returning unit type without 'impure' specifier may be optimized away by compiler
+inspection.func.missing.impure.fix.family.name=Add 'impure' specifier
+inspection.func.missing.impure.fix.text=Add 'impure' specifier

--- a/modules/func/src/org/ton/intellij/func/inspection/style/FuncMissingImpureInspection.kt
+++ b/modules/func/src/org/ton/intellij/func/inspection/style/FuncMissingImpureInspection.kt
@@ -1,0 +1,106 @@
+package org.ton.intellij.func.inspection.style
+
+import com.intellij.codeInspection.*
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.ton.intellij.func.FuncBundle
+import org.ton.intellij.func.inspection.FuncInspectionBase
+import org.ton.intellij.func.psi.*
+
+class FuncMissingImpureInspection : FuncInspectionBase() {
+    override fun buildFuncVisitor(
+        holder: ProblemsHolder,
+        session: LocalInspectionToolSession,
+    ): FuncVisitor = object : FuncVisitor() {
+        override fun visitFunction(function: FuncFunction) {
+            if (shouldHaveImpureSpecifier(function)) {
+                val identifier = function.identifier
+                holder.registerProblem(
+                    identifier,
+                    FuncBundle.message("inspection.func.missing.impure.message"),
+                    ProblemHighlightType.WEAK_WARNING,
+                    FuncAddImpureFix(function)
+                )
+            }
+        }
+    }
+
+    private fun shouldHaveImpureSpecifier(function: FuncFunction): Boolean {
+        if (hasSpecifier(function, "impure") || hasSpecifier(function, "method_id")) {
+            return false
+        }
+        if (function.name == "main" || function.name == "recv_internal" || function.name == "recv_external") {
+            return false
+        }
+        if (function.asmDefinition != null) {
+            return false
+        }
+
+        val returnType = function.typeReference
+        return returnsUnitType(returnType)
+    }
+
+    private fun hasSpecifier(function: FuncFunction, name: String): Boolean {
+        var current: PsiElement? = function.firstChild
+        while (current != null) {
+            if (current.text == name) {
+                return true
+            }
+            current = current.nextSibling
+        }
+        return false
+    }
+
+    private fun returnsUnitType(typeReference: FuncTypeReference?): Boolean {
+        if (typeReference is FuncUnitType) {
+            return true
+        }
+        return typeReference?.text == "()"
+    }
+}
+
+class FuncAddImpureFix(
+    element: PsiElement,
+) : LocalQuickFixAndIntentionActionOnPsiElement(element), LocalQuickFix {
+
+    override fun getFamilyName(): String = FuncBundle.message("inspection.func.missing.impure.fix.family.name")
+    override fun getText(): String = FuncBundle.message("inspection.func.missing.impure.fix.text")
+
+    override fun invoke(
+        project: Project,
+        file: PsiFile,
+        editor: Editor?,
+        startElement: PsiElement,
+        endElement: PsiElement,
+    ) {
+        val function = startElement as? FuncFunction ?: return
+        addImpureSpecifier(project, function)
+    }
+
+    private fun addImpureSpecifier(project: Project, function: FuncFunction) {
+        val functionBody = function.blockStatement ?: function.asmDefinition
+
+        val factory = FuncPsiFactory[project]
+        val impureKeyword = factory.createModifier("impure")
+        val space = factory.createWhitespace(" ")
+
+
+        if (functionBody != null) {
+            function.addBefore(space, functionBody)
+            function.addBefore(impureKeyword, functionBody)
+        } else {
+            val identifier = function.identifier
+            var current: PsiElement? = identifier.nextSibling
+            while (current != null) {
+                if (current.text == ";") {
+                    function.addBefore(space, current)
+                    function.addBefore(impureKeyword, current)
+                    break
+                }
+                current = current.nextSibling
+            }
+        }
+    }
+}

--- a/modules/func/src/org/ton/intellij/func/inspection/style/FuncMissingImpureInspection.kt
+++ b/modules/func/src/org/ton/intellij/func/inspection/style/FuncMissingImpureInspection.kt
@@ -86,7 +86,6 @@ class FuncAddImpureFix(
         val impureKeyword = factory.createModifier("impure")
         val space = factory.createWhitespace(" ")
 
-
         if (functionBody != null) {
             function.addBefore(space, functionBody)
             function.addBefore(impureKeyword, functionBody)

--- a/modules/func/src/org/ton/intellij/func/psi/FuncPsiFactory.kt
+++ b/modules/func/src/org/ton/intellij/func/psi/FuncPsiFactory.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
 import org.ton.intellij.func.FuncLanguage
+import org.ton.intellij.util.childrenWithLeaves
 import org.ton.intellij.util.descendantOfTypeStrict
 
 @Service(Service.Level.PROJECT)
@@ -187,6 +188,13 @@ class FuncPsiFactory private constructor(val project: Project) {
         val funcFile = createFile("() $text() {}")
         val function = funcFile.functions.first()
         return function.identifier
+    }
+
+    fun createModifier(text: String): PsiElement {
+        val funcFile = createFile("() foo() $text {}")
+        val function = funcFile.functions.first()
+        return function.childrenWithLeaves.find { it.text == text }
+            ?: error("Failed to create modifier: `$text`")
     }
 
     fun createIncludeDefinition(text: String): FuncIncludeDefinition =


### PR DESCRIPTION


Fixes #128