### PR TITLE
feat(tolk/completion): add `return <expr>;` completion item for functions without an explicit return type

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkReturnCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkReturnCompletionProvider.kt
@@ -29,6 +29,21 @@ object TolkReturnCompletionProvider : TolkCompletionProvider(), DumbAware {
     ) {
         val outerFunction = parameters.position.parentOfType<TolkFunction>() ?: return
 
+        if (outerFunction.returnType == null) {
+            // no explicit return type
+            result.addElement(
+                LookupElementBuilder.create("return")
+                    .bold()
+                    .withTailText(" expr;", true)
+                    .withInsertHandler(
+                        TemplateStringInsertHandler(
+                            " \$expr$;", true, "expr" to ConstantNode("")
+                        )
+                    )
+                    .toTolkLookupElement(TolkLookupElementData(keywordKind = KEYWORD))
+            )
+        }
+
         val returnTy = outerFunction.returnTy
         if (returnTy is TolkTyVoid) {
             result.addElement(

--- a/modules/tolk/test/completion/TolkCompletionTest.kt
+++ b/modules/tolk/test/completion/TolkCompletionTest.kt
@@ -287,9 +287,20 @@ class TolkCompletionTest : TolkCompletionTestBase() {
         }
     """, """
         fun foo() {
-            return;/*caret*/
+            return ;/*caret*/
         }
     """.trimIndent())
+
+    fun `test return, no explicit return type`() = checkEquals(
+        """
+            fun foo() {
+                return/*caret*/
+            }
+        """,
+        1,
+        "return", // expr
+        "return;",
+    )
 
     fun `test return, int type`() = doFirstCompletion("""
         fun foo(): int {


### PR DESCRIPTION

Fixes #512