### PR TITLE
feat(tolk): support enum serialization `enum Foo: uint8 {}`

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
@@ -394,6 +394,12 @@ fun TolkEnum.generateDoc(): String {
 
         colorize(name ?: "", asEnum)
 
+        val serializationType = typeExpression?.type
+        if (serializationType != null) {
+            append(": ")
+            append(serializationType.generateDoc())
+        }
+
         generateEnumMembers(enumBody?.enumMemberList ?: emptyList())
 
         append(DocumentationMarkup.DEFINITION_END)

--- a/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
+++ b/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
@@ -282,7 +282,7 @@ private StructFieldDefault ::= '=' Expression {
     recoverWhile = StructField_recover
 }
 
-upper Enum ::= 'enum' IDENTIFIER EnumBody {
+upper Enum ::= 'enum' IDENTIFIER (':' TypeExpression) EnumBody {
     pin=1
     mixin = "org.ton.intellij.tolk.psi.impl.TolkEnumMixin"
     implements = [

--- a/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
+++ b/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
@@ -282,7 +282,7 @@ private StructFieldDefault ::= '=' Expression {
     recoverWhile = StructField_recover
 }
 
-upper Enum ::= 'enum' IDENTIFIER (':' TypeExpression) EnumBody {
+upper Enum ::= 'enum' IDENTIFIER (':' TypeExpression)? EnumBody {
     pin=1
     mixin = "org.ton.intellij.tolk.psi.impl.TolkEnumMixin"
     implements = [

--- a/modules/tolk/test/completion/TolkCompletionTest.kt
+++ b/modules/tolk/test/completion/TolkCompletionTest.kt
@@ -822,6 +822,15 @@ class TolkCompletionTest : TolkCompletionTestBase() {
         }
     """.trimIndent())
 
+    fun `test enum serialization type`() = checkContainsCompletion(
+        "uint8",
+        """
+            enum Color: /*caret*/ {
+                Red
+            }
+        """,
+    )
+
 //    fun `test caret navigation in self method`() = doSingleCompletion("""
 //        struct Foo;
 //        fun Foo.foo(self) {}

--- a/modules/tolk/testResources/documentation/enums.expected.html
+++ b/modules/tolk/testResources/documentation/enums.expected.html
@@ -153,5 +153,21 @@
 <span style="">}</span></pre></div>
         </div>
     </div>
+    <div class="element">
+        <div class="element-title">TolkEnumMemberImpl</div>
+        <div class="documentation">
+            <div class='definition'><pre><span style="color:#000080;font-weight:bold;">enum</span> <span style="color:#000000;">Color</span>
+<span style="color:#660e7a;font-style:italic;">Red</span></pre></div>
+        </div>
+    </div>
+    <div class="element">
+        <div class="element-title">TolkEnumImpl</div>
+        <div class="documentation">
+            <div class='definition'><pre>
+<span style="color:#000080;font-weight:bold;">enum</span> <span style="color:#000000;">Color</span>: <span style="color:#000080;font-weight:bold;">uint8</span><span style=""> {</span>
+   <span style="color:#660e7a;font-style:italic;">Red</span>
+<span style="">}</span></pre></div>
+        </div>
+    </div>
 </body>
 </html>

--- a/modules/tolk/testResources/documentation/enums.tolk
+++ b/modules/tolk/testResources/documentation/enums.tolk
@@ -17,3 +17,7 @@ enum EPartialAssigned {
     P6 = SIX,
     Max = 0x7FFFFFFF,
 }
+
+enum Color: uint8 {
+    Red,
+}


### PR DESCRIPTION
Fixes #517