### PR TITLE
feat(tolk): initial support for `readonly` and `private` modifiers

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
@@ -56,6 +56,7 @@ import org.ton.intellij.tolk.psi.TolkTypeParameter
 import org.ton.intellij.tolk.psi.TolkTypeParameterList
 import org.ton.intellij.tolk.psi.TolkVar
 import org.ton.intellij.tolk.psi.TolkVarExpression
+import org.ton.intellij.tolk.psi.impl.TolkStructFieldMixin
 import org.ton.intellij.tolk.psi.impl.hasReceiver
 import org.ton.intellij.tolk.psi.impl.receiverTy
 import org.ton.intellij.tolk.psi.impl.returnTy
@@ -365,6 +366,18 @@ fun TolkStructField.generateDoc(): String {
             append("\n")
         }
 
+        val modifiers = mutableListOf<String>()
+        val mixin = this@generateDoc as? TolkStructFieldMixin
+        if (mixin?.isPrivate == true) modifiers.add("private")
+        if (mixin?.isReadonly == true) modifiers.add("readonly")
+        
+        if (modifiers.isNotEmpty()) {
+            modifiers.forEach { modifier ->
+                colorize(modifier, asKeyword)
+                append(" ")
+            }
+        }
+
         colorize(name ?: "", asField)
         append(": ")
 
@@ -609,6 +622,19 @@ private fun StringBuilder.generateStructFields(fields: List<TolkStructField>) {
         fields.joinToString("\n") { field ->
             buildString {
                 append("   ")
+                
+                val modifiers = mutableListOf<String>()
+                val mixin = field as? TolkStructFieldMixin
+                if (mixin?.isPrivate == true) modifiers.add("private")
+                if (mixin?.isReadonly == true) modifiers.add("readonly")
+                
+                if (modifiers.isNotEmpty()) {
+                    modifiers.forEach { modifier ->
+                        colorize(modifier, asKeyword)
+                        append(" ")
+                    }
+                }
+                
                 colorize(field.name ?: "", asField)
                 append(": ")
 

--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCompletionContributor.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCompletionContributor.kt
@@ -81,6 +81,7 @@ class TolkCompletionContributor : CompletionContributor() {
         extend(TolkReturnCompletionProvider)
         extend(TolkTopLevelSnippetsCompletionProvider)
         extend(TolkFunctionNameCompletionProvider)
+        extend(TolkStructFieldModifierCompletionProvider)
     }
 
     fun extend(provider: TolkCompletionProvider) {

--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkKeywordCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkKeywordCompletionProvider.kt
@@ -19,7 +19,7 @@ class TolkKeywordCompletionProvider(
 ) : CompletionProvider<CompletionParameters>() {
     constructor(priority: Double, vararg keywords: String) : this(priority, keywords.toList())
 
-    override fun addCompletions(
+    public override fun addCompletions(
         parameters: CompletionParameters,
         context: ProcessingContext,
         result: CompletionResultSet,

--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkStructFieldModifierCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkStructFieldModifierCompletionProvider.kt
@@ -1,0 +1,35 @@
+package org.ton.intellij.tolk.ide.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PatternCondition
+import com.intellij.patterns.PlatformPatterns.psiElement
+import com.intellij.psi.PsiElement
+import com.intellij.util.ProcessingContext
+import org.ton.intellij.tolk.psi.TolkStructBody
+import org.ton.intellij.tolk.psi.TolkStructField
+import org.ton.intellij.util.prevVisibleOrNewLine
+
+object TolkStructFieldModifierCompletionProvider : TolkCompletionProvider() {
+    override val elementPattern: ElementPattern<out PsiElement> = psiElement()
+        .inside(TolkStructBody::class.java)
+        .andNot(psiElement().withParent(TolkStructField::class.java).afterLeaf(":"))
+        .and(psiElement().with(object : PatternCondition<PsiElement>("notAfterColon") {
+            override fun accepts(t: PsiElement, context: ProcessingContext?): Boolean {
+                return t.prevVisibleOrNewLine?.text != ":"
+            }
+        }))
+
+    override fun addCompletions(
+        parameters: CompletionParameters,
+        context: ProcessingContext,
+        result: CompletionResultSet
+    ) {
+        val provider = TolkKeywordCompletionProvider(
+            TolkCompletionContributor.CONTEXT_KEYWORD_PRIORITY,
+            listOf("private", "readonly")
+        )
+        provider.addCompletions(parameters, context, result)
+    }
+}

--- a/modules/tolk/src/org/ton/intellij/tolk/lexer/TolkLexer.flex
+++ b/modules/tolk/src/org/ton/intellij/tolk/lexer/TolkLexer.flex
@@ -280,6 +280,8 @@ EOL_DOC_LINE  = {LINE_WS}*!(!(("///").*)|(("////").*))
       "as"                     { return AS_KEYWORD; }
       "is"                     { return IS_KEYWORD; }
       "self"                   { return SELF_KEYWORD; }
+      "private"                { return PRIVATE_KEYWORD; }
+      "readonly"               { return READONLY_KEYWORD; }
 
       {INTEGER_LITERAL}        { return INTEGER_LITERAL; }
       {THREE_QUO}              { pushState(RAW_STRING); return OPEN_QUOTE; }

--- a/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
+++ b/modules/tolk/src/org/ton/intellij/tolk/parser/TolkParser.bnf
@@ -129,6 +129,8 @@
             LAZY_KEYWORD                 = 'LAZY_KEYWORD'
             IMPORT_KEYWORD              = 'import'
             TOLK_KEYWORD                = 'tolk'
+            PRIVATE_KEYWORD             = 'private'
+            READONLY_KEYWORD            = 'readonly'
 
             ESCAPE_SEQUENCE = "ESCAPE_SEQUENCE"
             DANGLING_NEWLINE = "DANGLING_NEWLINE"
@@ -263,8 +265,8 @@ private StructBodyElements ::= (StructBody_MultipleElement | StructBody_SingleEl
 private StructBody_SingleElement ::= StructField
 private StructBody_MultipleElement ::= StructField ((','|';')? StructField)+
 
-StructField ::= IDENTIFIER ':' TypeExpression StructFieldDefault? {
-    pin = 1
+StructField ::= StructFieldModifiers? IDENTIFIER ':' TypeExpression StructFieldDefault? {
+    pin = 2
     recoverWhile = StructField_recover
     mixin="org.ton.intellij.tolk.psi.impl.TolkStructFieldMixin"
     implements=[
@@ -277,6 +279,10 @@ StructField ::= IDENTIFIER ':' TypeExpression StructFieldDefault? {
     hooks = [ leftBinder = "ADJACENT_LINE_COMMENTS" ]
 }
 private StructField_recover ::= !(';'|','|'}'|IDENTIFIER)
+
+StructFieldModifiers ::= StructFieldModifier+ {}
+StructFieldModifier ::= 'private' | 'readonly' {}
+
 private StructFieldDefault ::= '=' Expression {
     pin=1
     recoverWhile = StructField_recover

--- a/modules/tolk/src/org/ton/intellij/tolk/psi/TolkTokenType.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/psi/TolkTokenType.kt
@@ -55,6 +55,8 @@ val TOLK_KEYWORDS = tokenSetOf(
     TolkElementTypes.IS_KEYWORD,
     TolkElementTypes.NOT_IS_KEYWORD,
     TolkElementTypes.SELF_KEYWORD,
+    TolkElementTypes.PRIVATE_KEYWORD,
+    TolkElementTypes.READONLY_KEYWORD,
 )
 
 val TOLK_NUMBERS = tokenSetOf(

--- a/modules/tolk/src/org/ton/intellij/tolk/psi/impl/TolkStructFieldMixin.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/psi/impl/TolkStructFieldMixin.kt
@@ -24,6 +24,12 @@ abstract class TolkStructFieldMixin : TolkNamedElementImpl<TolkStructFieldStub>,
         get() = childOfType<TolkDocComment>()
 
     override fun getIcon(flags: Int): Icon = TolkIcons.FIELD
+
+    val isPrivate: Boolean
+        get() = structFieldModifiers?.structFieldModifierList?.any { it.text == "private" } == true
+
+    val isReadonly: Boolean
+        get() = structFieldModifiers?.structFieldModifierList?.any { it.text == "readonly" } == true
 }
 
 val TolkStructField.parentStruct: TolkStruct

--- a/modules/tolk/test/completion/TolkStructFieldModifierCompletionTest.kt
+++ b/modules/tolk/test/completion/TolkStructFieldModifierCompletionTest.kt
@@ -1,0 +1,181 @@
+package org.ton.intellij.tolk.completion
+
+class TolkStructFieldModifierCompletionTest : TolkCompletionTestBase() {
+    
+    fun `test private modifier completion in struct body`() = checkContainsCompletion(
+        "private",
+        """
+            struct MyStruct {
+                priv/*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test readonly modifier completion in struct body`() = checkContainsCompletion(
+        "readonly",
+        """
+            struct MyStruct {
+                read/*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test both modifiers available in struct body`() = checkContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            struct MyStruct {
+                /*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test private modifier completion after typing pr`() = doSingleCompletion(
+        """
+            struct MyStruct {
+                pr/*caret*/
+            }
+        """,
+        """
+            struct MyStruct {
+                private /*caret*/
+            }
+        """
+    )
+    
+    fun `test readonly modifier completion after typing re`() = doSingleCompletion(
+        """
+            struct MyStruct {
+                re/*caret*/
+            }
+        """,
+        """
+            struct MyStruct {
+                readonly /*caret*/
+            }
+        """
+    )
+    
+    fun `test private completion and field definition`() = doFirstCompletion(
+        """
+            struct MyStruct {
+                priv/*caret*/ field: int;
+            }
+        """,
+        """
+            struct MyStruct {
+                private /*caret*/ field: int;
+            }
+        """
+    )
+    
+    fun `test readonly completion and field definition`() = doFirstCompletion(
+        """
+            struct MyStruct {
+                read/*caret*/ field: int;
+            }
+        """,
+        """
+            struct MyStruct {
+                readonly /*caret*/ field: int;
+            }
+        """
+    )
+    
+    fun `test modifiers not available after field name`() = checkNotContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            struct MyStruct {
+                field: /*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test modifiers not available after colon`() = checkNotContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            struct MyStruct {
+                field: int/*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test modifiers not available outside struct`() = checkNotContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            priv/*caret*/
+            struct MyStruct {
+                field: int;
+            }
+        """.trimIndent()
+    )
+    
+    fun `test modifiers not available in function`() = checkNotContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            fun test() {
+                priv/*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test multiple modifiers completion`() = doFirstCompletion(
+        """
+            struct MyStruct {
+                private read/*caret*/
+            }
+        """,
+        """
+            struct MyStruct {
+                private readonly /*caret*/
+            }
+        """
+    )
+    
+    fun `test private after readonly completion`() = doFirstCompletion(
+        """
+            struct MyStruct {
+                readonly priv/*caret*/
+            }
+        """,
+        """
+            struct MyStruct {
+                readonly private /*caret*/
+            }
+        """
+    )
+
+    fun `test modifiers in nested struct`() = checkContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            struct Outer {
+                field: Inner;
+            }
+            
+            struct Inner {
+                /*caret*/
+            }
+        """.trimIndent()
+    )
+    
+    fun `test modifiers with multiple fields`() = checkContainsCompletion(
+        listOf("private", "readonly"),
+        """
+            struct MyStruct {
+                field1: int;
+                private field2: string;
+                /*caret*/
+            }
+        """.trimIndent()
+    )
+
+    fun `test readonly modifier completion priority`() = checkOrderedEquals(
+        """
+            struct MyStruct {
+                r/*caret*/
+            }
+        """.trimIndent(),
+        1,
+        "readonly",
+        "private",
+    )
+}

--- a/modules/tolk/testResources/documentation/struct.expected.html
+++ b/modules/tolk/testResources/documentation/struct.expected.html
@@ -111,5 +111,46 @@
 </div>
         </div>
     </div>
+    <div class="element">
+        <div class="element-title">Field: foo</div>
+        <div class="documentation">
+            <div class='definition'><pre><span style="color:#000080;font-weight:bold;">struct</span> <span style="color:#a04908;">Empty</span>
+<span style="color:#000080;font-weight:bold;">private</span> <span style="color:#660e7a;font-weight:bold;">foo</span>: <span style="color:#000080;font-weight:bold;">int</span></pre></div>
+        </div>
+    </div>
+    <div class="element">
+        <div class="element-title">Field: bar</div>
+        <div class="documentation">
+            <div class='definition'><pre><span style="color:#000080;font-weight:bold;">struct</span> <span style="color:#a04908;">Empty</span>
+<span style="color:#000080;font-weight:bold;">private</span> <span style="color:#000080;font-weight:bold;">readonly</span> <span style="color:#660e7a;font-weight:bold;">bar</span>: <span style="color:#000080;font-weight:bold;">int</span></pre></div>
+        </div>
+    </div>
+    <div class="element">
+        <div class="element-title">Field: bar</div>
+        <div class="documentation">
+            <div class='definition'><pre><span style="color:#000080;font-weight:bold;">struct</span> <span style="color:#a04908;">Empty</span>
+<span style="color:#000080;font-weight:bold;">readonly</span> <span style="color:#660e7a;font-weight:bold;">bar</span>: <span style="color:#000080;font-weight:bold;">int</span></pre></div>
+        </div>
+    </div>
+    <div class="element">
+        <div class="element-title">Field: baz</div>
+        <div class="documentation">
+            <div class='definition'><pre><span style="color:#000080;font-weight:bold;">struct</span> <span style="color:#a04908;">Empty</span>
+<span style="color:#660e7a;font-weight:bold;">baz</span>: <span style="color:#000080;font-weight:bold;">int</span></pre></div>
+        </div>
+    </div>
+    <div class="element">
+        <div class="element-title">Struct: Empty</div>
+        <div class="documentation">
+            <div class='definition'><pre>
+<span style="color:#000080;font-weight:bold;">struct</span> <span style="color:#a04908;">Empty</span><span style=""> {</span>
+   <span style="color:#000080;font-weight:bold;">private</span> <span style="color:#660e7a;font-weight:bold;">foo</span>: <span style="color:#000080;font-weight:bold;">int</span>
+   <span style="color:#000080;font-weight:bold;">private</span> <span style="color:#000080;font-weight:bold;">readonly</span> <span style="color:#660e7a;font-weight:bold;">bar</span>: <span style="color:#000080;font-weight:bold;">int</span>
+   <span style="color:#000080;font-weight:bold;">readonly</span> <span style="color:#660e7a;font-weight:bold;">bar</span>: <span style="color:#000080;font-weight:bold;">int</span>
+   <span style="color:#660e7a;font-weight:bold;">baz</span>: <span style="color:#000080;font-weight:bold;">int</span>
+<span style="">}</span></pre></div><div class='content'><p>Struct with private readonly fields</p>
+</div>
+        </div>
+    </div>
 </body>
 </html>

--- a/modules/tolk/testResources/documentation/struct.tolk
+++ b/modules/tolk/testResources/documentation/struct.tolk
@@ -21,3 +21,11 @@ struct(123) TaggedStruct {
 /// Empty struct
 struct Empty {
 }
+
+/// Struct with private readonly fields
+struct Empty {
+    private foo: int,
+    private readonly bar: int,
+    readonly bar: int,
+    baz: int,
+}


### PR DESCRIPTION
Fixes #516