### PR TITLE
fix(tolk/resolving): resolve a match pattern first to type and if unresolved — to other symbols

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/psi/reference/TolkMatchArmReference.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/psi/reference/TolkMatchArmReference.kt
@@ -11,11 +11,11 @@ class TolkMatchArmReference(
     element: TolkMatchPatternReference
 ) : PsiPolyVariantReferenceBase<TolkMatchPatternReference>(element) {
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult?> {
-        val symbolResult = TolkSymbolReference(element).multiResolve(incompleteCode)
-        if (symbolResult.isNotEmpty()) return symbolResult
-
         val typeResult = TolkTypeReference(element).multiResolve(incompleteCode)
         if (typeResult.isNotEmpty()) return typeResult
+
+        val symbolResult = TolkSymbolReference(element).multiResolve(incompleteCode)
+        if (symbolResult.isNotEmpty()) return symbolResult
 
         return ResolveResult.EMPTY_ARRAY
     }

--- a/modules/tolk/test/resolving/TolkResolveMatchPatternTest.kt
+++ b/modules/tolk/test/resolving/TolkResolveMatchPatternTest.kt
@@ -1,0 +1,40 @@
+package org.ton.intellij.tolk.resolving
+
+open class TolkResolveMatchPatternTest : TolkResolvingTestBase() {
+    fun `test type with same name as local variable`() {
+        mainFile(
+            "main.tolk",
+            """
+               type asdf = int;
+                
+               fun main() {
+                   var asdf = 5;
+                   return match (10) {
+                       /*caret*/asdf => {}
+                   };
+               }
+            """.trimIndent(),
+        )
+
+        assertReferencedTo("TYPE_DEF:asdf asdf")
+    }
+
+    fun `test type with same name as global variable`() {
+        mainFile(
+            "main.tolk",
+            """
+               type asdf = int;
+       
+               global asdf: int;
+                
+               fun main() {
+                   return match (10) {
+                       /*caret*/asdf => {}
+                   };
+               }
+            """.trimIndent(),
+        )
+
+        assertReferencedTo("TYPE_DEF:asdf asdf")
+    }
+}


### PR DESCRIPTION


Fixes #513