### PR TITLE
fix(tolk/type-inference): fix type inference for `a.1` for `tuple` type

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/type/TypeInference.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/type/TypeInference.kt
@@ -1520,6 +1520,14 @@ class TolkInferenceWalker(
                 hint
             )
             inferredType = fieldType
+            if (fieldType is TolkTyUnknown && fieldLookup.integerLiteral != null && hint != null) {
+                // var a = createEmptyTuple();
+                // var b: int = a.1;
+                //
+                // hint = int
+                inferredType = hint
+            }
+
             if (resolvedVariants.isNotEmpty()) {
                 fieldSymbol = resolvedVariants.singleOrNull()
                 ctx.setResolvedRefs(fieldLookup, resolvedVariants.map { PsiElementResolveResult(it) })


### PR DESCRIPTION
Fixes #546