### PR TITLE
fix(tolk/documentation): don't highlight `->` as a keyword in hover documentation

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/doc/TolkDocumentationProvider.kt
@@ -175,7 +175,7 @@ fun TolkTy.generateDoc(): String = buildString {
             }
             colorize(")", asParen)
             append(" ")
-            colorize("->", asKeyword)
+            colorize("->", asComma)
             append(" ")
             append(returnType.generateDoc())
         }

--- a/modules/tolk/testResources/documentation/advanced_types.expected.html
+++ b/modules/tolk/testResources/documentation/advanced_types.expected.html
@@ -73,7 +73,7 @@
     <div class="element">
         <div class="element-title">Parameter: callback</div>
         <div class="documentation">
-            <div class='definition'><pre><span style="color:#000000;">callback</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#20999d;">T</span><span style="">)</span> <span style="color:#000080;font-weight:bold;">-&gt;</span> <span style="color:#20999d;">U</span></pre></div>
+            <div class='definition'><pre><span style="color:#000000;">callback</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#20999d;">T</span><span style="">)</span> <span style="">-&gt;</span> <span style="color:#20999d;">U</span></pre></div>
         </div>
     </div>
     <div class="element">
@@ -96,7 +96,7 @@
    <span style="color:#000080;font-weight:bold;">self</span><span style="">, </span>
    <span style="color:#000000;">generic</span>:  <span style="color:#20999d;">T</span>,
    <span style="color:#000000;">nullable</span>: <span style="color:#20999d;">T</span><span style="">?</span>,
-   <span style="color:#000000;">callback</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#20999d;">T</span><span style="">)</span> <span style="color:#000080;font-weight:bold;">-&gt;</span> <span style="color:#20999d;">U</span>,
+   <span style="color:#000000;">callback</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#20999d;">T</span><span style="">)</span> <span style="">-&gt;</span> <span style="color:#20999d;">U</span>,
    <span style="color:#000000;">mixed</span>:    <span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#20999d;">T</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">)</span>,
    <span style="color:#000000;">typed</span>:    <span style="">[</span><span style="color:#20999d;">T</span><span style="">, </span><span style="color:#20999d;">U</span><span style="">, </span><span style="color:#000080;font-weight:bold;">bool</span><span style="">]</span>,
 <span style="">)</span>: <span style="">(</span><span style="color:#20999d;">T</span><span style="">, </span><span style="color:#20999d;">U</span><span style="">)</span></pre></div><div class='content'><p>Function with advanced type features</p>

--- a/modules/tolk/testResources/documentation/complex_types.expected.html
+++ b/modules/tolk/testResources/documentation/complex_types.expected.html
@@ -55,7 +55,7 @@
     <div class="element">
         <div class="element-title">Parameter: function_param</div>
         <div class="documentation">
-            <div class='definition'><pre><span style="color:#000000;">function_param</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">)</span> <span style="color:#000080;font-weight:bold;">-&gt;</span> <span style="color:#000080;font-weight:bold;">slice</span></pre></div>
+            <div class='definition'><pre><span style="color:#000000;">function_param</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">)</span> <span style="">-&gt;</span> <span style="color:#000080;font-weight:bold;">slice</span></pre></div>
         </div>
     </div>
     <div class="element">
@@ -66,7 +66,7 @@
    <span style="color:#000000;">tensor</span>:         <span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">, </span><span style="color:#000080;font-weight:bold;">bool</span><span style="">)</span>,
    <span style="color:#000000;">tuple</span>:          <span style="">[</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">]</span>,
    <span style="color:#000000;">nullable</span>:       <span style="color:#000080;font-weight:bold;">int</span><span style="">?</span>,
-   <span style="color:#000000;">function_param</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">)</span> <span style="color:#000080;font-weight:bold;">-&gt;</span> <span style="color:#000080;font-weight:bold;">slice</span>,
+   <span style="color:#000000;">function_param</span>: <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">)</span> <span style="">-&gt;</span> <span style="color:#000080;font-weight:bold;">slice</span>,
 <span style="">)</span>: <span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">)</span></pre></div><div class='content'><p>Function with complex types</p>
 </div>
         </div>

--- a/modules/tolk/testResources/documentation/type_def.expected.html
+++ b/modules/tolk/testResources/documentation/type_def.expected.html
@@ -74,7 +74,7 @@
         <div class="element-title">Type: ComplexType</div>
         <div class="documentation">
             <div class='definition'><pre>
-<span style="color:#000080;font-weight:bold;">type</span> <span style="color:#a04908;font-style:italic;">ComplexType</span> = <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">)</span> <span style="color:#000080;font-weight:bold;">-&gt;</span> <span style="color:#000080;font-weight:bold;">bool</span></pre></div><div class='content'><p>Complex type alias</p>
+<span style="color:#000080;font-weight:bold;">type</span> <span style="color:#a04908;font-style:italic;">ComplexType</span> = <span style="color:#000080;font-weight:bold;">fun </span><span style="">(</span><span style="color:#000080;font-weight:bold;">int</span><span style="">, </span><span style="color:#000080;font-weight:bold;">slice</span><span style="">)</span> <span style="">-&gt;</span> <span style="color:#000080;font-weight:bold;">bool</span></pre></div><div class='content'><p>Complex type alias</p>
 </div>
         </div>
     </div>


### PR DESCRIPTION


Fixes #549