### PR TITLE
feat(tolk/inspections): remove type when rename unused tensor/tuple variable to `_` via quickfix

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/ide/fixes/RenameUnserscoreFix.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/fixes/RenameUnserscoreFix.kt
@@ -7,8 +7,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import org.ton.intellij.tolk.psi.TolkNamedElement
+import org.ton.intellij.tolk.psi.TolkPsiFactory
+import org.ton.intellij.tolk.psi.TolkVarTensor
+import org.ton.intellij.tolk.psi.TolkVarTuple
 
-// TODO: fix apply expressions
 class RenameUnderscoreFix(
     val element: TolkNamedElement
 ) : LocalQuickFixAndIntentionActionOnPsiElement(element) {
@@ -25,6 +27,10 @@ class RenameUnderscoreFix(
         startElement: PsiElement,
         endElement: PsiElement
     ) {
+        if (element.parent is TolkVarTensor || element.parent is TolkVarTuple) {
+            element.replace(TolkPsiFactory[project].createIdentifier("_"))
+            return
+        }
         element.setName("_")
     }
 }

--- a/modules/tolk/test/quickfix/quickfix/TolkRenameToUnderscoreQuickfixTest.kt
+++ b/modules/tolk/test/quickfix/quickfix/TolkRenameToUnderscoreQuickfixTest.kt
@@ -1,0 +1,61 @@
+package org.ton.intellij.tolk.quickfix.quickfix
+
+import org.ton.intellij.tolk.ide.configurable.tolkSettings
+import org.ton.intellij.tolk.inspection.TolkUnresolvedReferenceInspection
+import org.ton.intellij.tolk.inspection.TolkUnusedVariableInspection
+import org.ton.intellij.tolk.quickfix.TolkQuickfixTestBase
+
+class TolkRenameToUnderscoreQuickfixTest : TolkQuickfixTestBase() {
+    override fun setUp() {
+        super.setUp()
+        val file = myFixture.copyDirectoryToProject("tolk-stdlib", "tolk-stdlib")
+        project.tolkSettings.explicitPathToStdlib = file.url
+        myFixture.enableInspections(TolkUnusedVariableInspection::class.java)
+    }
+
+    fun `test rename unused variable`() = doQuickfixTest(
+        """
+            fun test() {
+                var a/*caret*/ = 100;
+            }
+        """.trimIndent(),
+        """
+            fun test() {
+                var _ = 100;
+            }
+        """.trimIndent(),
+        "Rename element",
+    )
+
+    fun `test rename unused variable in tensor variable`() = doQuickfixTest(
+        """
+            fun test() {
+                var (a: int, b/*caret*/: int) = (1, 2);
+                throw a;
+            }
+        """.trimIndent(),
+        """
+            fun test() {
+                var (a: int, _) = (1, 2);
+                throw a;
+            }
+        """.trimIndent(),
+        "Rename element",
+    )
+
+    fun `test rename unused variable in tuple variable`() = doQuickfixTest(
+        """
+            fun test() {
+                var [a: int, b/*caret*/: int] = [1, 2];
+                throw a;
+            }
+        """.trimIndent(),
+        """
+            fun test() {
+                var [a: int, _] = [1, 2];
+                throw a;
+            }
+        """.trimIndent(),
+        "Rename element",
+    )
+}


### PR DESCRIPTION
Fixes #557