### PR TITLE
fix(tolk/completion): don't add duplicate completion variant for primitive types in Tolk 1.1

### DIFF
--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCommonCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkCommonCompletionProvider.kt
@@ -156,6 +156,12 @@ object TolkCommonCompletionProvider : TolkCompletionProvider() {
                         return expectType.variants.any { it != type && it.canRhsBeAssigned(type) }
                     }
 
+                    if (element is TolkTypeDef) {
+                        if (element.builtinKeyword != null) {
+                            return true
+                        }
+                    }
+
                     val canAddAsUnionMatchVariant = canAddAsUnionMatchVariant()
                     if (inMatchPattern && expectType is TolkTyUnion && !canAddAsUnionMatchVariant) {
                         // union variant has already been processed

--- a/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkTypeCompletionProvider.kt
+++ b/modules/tolk/src/org/ton/intellij/tolk/ide/completion/TolkTypeCompletionProvider.kt
@@ -108,7 +108,13 @@ object TolkTypeCompletionProvider : TolkCompletionProvider() {
             true
         }
 
-        typeCandidates.forEach { typeDef ->
+        for (typeDef in typeCandidates) {
+            if (typeDef is TolkTypeDef) {
+                if (typeDef.builtinKeyword != null) {
+                    continue
+                }
+            }
+
             result.addElement(typeDef.toLookupElementBuilder(ctx))
         }
     }


### PR DESCRIPTION


Fixes #560